### PR TITLE
Replace travis with github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: Unit tests
+on: [push]
+
+jobs:
+  build:
+    name: Unit Tests node-${{ matrix.node_version }}, ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [10, 12, 14, 16, 17]
+        include:
+          - os: macos-latest
+            node_version: 16
+          - os: windows-latest
+            node_version: 16
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set node version to ${{ matrix.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - name: install
+        run: yarn install --immutable
+      - name: test
+        run: yarn test --ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-    - "10"
-    - "12"
-    - "lts/*"
-sudo: false

--- a/src/filtered-fix.test.js
+++ b/src/filtered-fix.test.js
@@ -75,14 +75,14 @@ describe('filtered-fix', () => {
       const filepath = path.resolve(path.join(fixtureDir, './no-semi.js'));
       const report = filteredFix.fix(filepath);
       expect(report.errorCount).toBe(0);
-      expect(shell.cat(filepath).stdout).toBe('var foo = 42;\n');
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}`);
     });
 
     it('fixes all rules if an empty options object specified', () => {
       const filepath = path.resolve(path.join(fixtureDir, './no-semi.js'));
       const report = filteredFix.fix(filepath, {});
       expect(report.errorCount).toBe(0);
-      expect(shell.cat(filepath).stdout).toBe('var foo = 42;\n');
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}`);
     });
 
     it('applies fixes to files', () => {
@@ -112,7 +112,7 @@ describe('filtered-fix', () => {
       const report = filteredFix.fix(filepath, fixOptions);
       expect(report.errorCount).toBe(1);
       expect(report.results[0].filePath).toBe(filepath);
-      expect(shell.cat(filepath).stdout).toBe('var foo = 42\n');
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42${os.EOL}`);
     });
 
     it('performs fixes if rule is specified', () => {
@@ -120,7 +120,7 @@ describe('filtered-fix', () => {
       const fixOptions = {rules: ['semi']};
       const report = filteredFix.fix(filepath, fixOptions);
       expect(report.errorCount).toBe(0);
-      expect(shell.cat(filepath).stdout).toBe('var foo = 42;\n');
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}`);
     });
 
     it('performs fixes for multiple rules', () => {
@@ -128,7 +128,7 @@ describe('filtered-fix', () => {
       const fixOptions = {rules: ['semi', 'newline-after-var']};
       const report = filteredFix.fix(filepath, fixOptions);
       expect(report.errorCount).toBe(1);
-      expect(shell.cat(filepath).stdout).toBe('var foo = 42;\n\nif (foo == 42) {\n    foo++;\n}\n');
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}\nif (foo == 42) {${os.EOL}    foo++;${os.EOL}}${os.EOL}`);
     });
 
     it('does not fix warnings if warnings option is false', () => {
@@ -136,7 +136,7 @@ describe('filtered-fix', () => {
       const fixOptions = {warnings: false};
       const report = filteredFix.fix(filepath, fixOptions);
       expect(report.warningCount).toBe(1);
-      expect(shell.cat(filepath).stdout).toBe('var a = (b * c);\n');
+      expect(shell.cat(filepath).toString()).toBe(`var a = (b * c);${os.EOL}`);
     });
   });
 });


### PR DESCRIPTION
Swaps out Travis CI for github actions, and expands node versions to include 16 and 17, and operating systems to include windows and mac.