### PR TITLE
Allow specifying array argument multiple times

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -30,11 +30,13 @@ module.exports = optionator({
     type       : '[String]',
     default    : '.js',
     description: 'Specify JavaScript file extensions',
+    concatRepeatedArrays: true,
   }, {
     option     : 'rule',
     alias      : 'r',
     type       : '[String]',
     description: 'Specify one or more rules to fix',
+    concatRepeatedArrays: true,
   }, {
     option     : 'warnings',
     alias      : 'w',


### PR DESCRIPTION
This is already mentioned in the readme, but the ["concatRepeatedArrays" flag of optionator](https://www.npmjs.com/package/optionator#option-properties) is set to false by default, so this feature did not work.