### PR TITLE
Fix rules with slash not working on Windows

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,7 @@ const cli = {
       currentOptions = options.parse(args);
       files = currentOptions._;
       extensions = currentOptions.ext;
-      rules = currentOptions.rule;
+      rules = currentOptions.rule.map(r => r.replace(/\\/g, "/");
       warnings = currentOptions.warnings;
     } catch (error) {
       console.error(error.message);


### PR DESCRIPTION
I assume that optionator parses strings as file names (as there's [a similar bug reported here](https://github.com/gkz/optionator/issues/34)), so on Windows it turns slashes in rule names into backslashes.

I haven't encountered rules that contain spaces, so this may be enough to fix related issues for now.