### PR TITLE
Improve performance by adding a rule filter to ensure that only focused rules are evaluated in lint

### DIFF
--- a/src/filtered-fix.js
+++ b/src/filtered-fix.js
@@ -61,7 +61,8 @@ async function fix(files, fixOptions, eslintOptions) {
 
   const fixFunc = makeFixer(fixOptions);
   const cliOptions = Object.assign({}, eslintOptions, { fix: fixFunc });
-  if (fixOptions && fixOptions.rules) {
+  const majorVersion = parseInt(ESLint.version.split('.')[0]);
+  if (fixOptions && fixOptions.rules && majorVersion > 8) {
     cliOptions.ruleFilter = (ruleId) => fixOptions.rules.includes(ruleId);
   }
   const eslintCli = getEslintCli(cliOptions);

--- a/src/filtered-fix.js
+++ b/src/filtered-fix.js
@@ -61,6 +61,9 @@ async function fix(files, fixOptions, eslintOptions) {
 
   const fixFunc = makeFixer(fixOptions);
   const cliOptions = Object.assign({}, eslintOptions, { fix: fixFunc });
+  if (fixOptions && fixOptions.rules) {
+    cliOptions.ruleFilter = (ruleId) => fixOptions.rules.includes(ruleId);
+  }
   const eslintCli = getEslintCli(cliOptions);
   const report = await calculateFixes(fileList, eslintCli);
   await applyFixes(report);

--- a/src/filtered-fix.js
+++ b/src/filtered-fix.js
@@ -63,7 +63,7 @@ async function fix(files, fixOptions, eslintOptions) {
   const cliOptions = Object.assign({}, eslintOptions, { fix: fixFunc });
   const majorVersion = parseInt(ESLint.version.split('.')[0]);
   if (fixOptions && fixOptions.rules && majorVersion > 8) {
-    cliOptions.ruleFilter = (ruleId) => fixOptions.rules.includes(ruleId);
+    cliOptions.ruleFilter = (rule) => fixOptions.rules.includes(rule.ruleId);
   }
   const eslintCli = getEslintCli(cliOptions);
   const report = await calculateFixes(fileList, eslintCli);


### PR DESCRIPTION
I was trying to improve the speed of eslint-nibble in certain workflows -- in this case, notably, while autofixing fixable lint infractions. I wrapped each statement of the fix function here with a console.time/timeEnd including the full function. As we can see, the `calculateFixes` call is the main contributor to the total time:

```
{ options: { fix: [Function (anonymous)] } }
makeFixer: 0.167ms
getEslintCli: 2.673ms
calculateFixes: 53.278s
applyFixes: 1.861ms
calculateFixes 2: 52.671s
fix: 1:45.956 (m:ss.mmm)
```

Assumedly the reason is due to needing to run every rule on every file -- even though we've already cut down the rules that we care about.

Obviously we can't statically override rule configs as they are dynamic and recursively defined; however, we can add a rule filter to turn off any rules we do not care about.

```
{
  options: {
    cache: true,
    fix: [Function (anonymous)],
    ruleFilter: [Function: ruleFilter]
  }
}
makeFixer: 0.2ms
getEslintCli: 47.422ms
calculateFixes: 2.153s
applyFixes: 0.195ms
calculateFixes 2: 140.463ms
fix: 2.342s
```

On a fairly large project with a robust ruleset, this reduced the inclusive time of the fix function from 1m 46s to 2.3s. I can't think of any issues this would create, but please review and let me know if I'm crazy here!

Edit -- found an issue which was that the config setting was added in eslint v9, so... now I'm checking for that.