### PR TITLE
Resolves unit test issues

### DIFF
--- a/src/filtered-fix.test.js
+++ b/src/filtered-fix.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const os = require('os');
 const fs = require('fs');
 const crypto = require('crypto');
 const shell = require('shelljs');
@@ -86,14 +85,14 @@ describe('filtered-fix', () => {
       const filepath = path.resolve(path.join(fixtureDir, './no-semi.js'));
       const [report] = await filteredFix.fix(filepath);
       expect(report.errorCount).toBe(0);
-      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}`);
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;\n`);
     });
 
     it('fixes all rules if an empty options object specified', async () => {
       const filepath = path.resolve(path.join(fixtureDir, './no-semi.js'));
       const [report] = await filteredFix.fix(filepath, {});
       expect(report.errorCount).toBe(0);
-      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}`);
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;\n`);
     });
 
     it('applies fixes to files', async () => {
@@ -124,7 +123,7 @@ describe('filtered-fix', () => {
       const [report] = await eslintCli.lintFiles([filepath]);
       expect(report.errorCount).toBe(1);
       expect(report.filePath).toBe(filepath);
-      expect(shell.cat(filepath).toString()).toBe(`var foo = 42${os.EOL}`);
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42\n`);
     });
 
     it('performs fixes if rule is specified', async () => {
@@ -132,7 +131,7 @@ describe('filtered-fix', () => {
       const fixOptions = { rules: ['semi'] };
       const [report] = await filteredFix.fix(filepath, fixOptions);
       expect(report.errorCount).toBe(0);
-      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}`);
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;\n`);
     });
 
     it('performs fixes for multiple rules', async () => {
@@ -141,7 +140,7 @@ describe('filtered-fix', () => {
       await filteredFix.fix(filepath, fixOptions);
       const [report] = await eslintCli.lintFiles([filepath]);
       expect(report.errorCount).toBe(1);
-      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;${os.EOL}\nif (foo == 42) {${os.EOL}    foo++;${os.EOL}}${os.EOL}`);
+      expect(shell.cat(filepath).toString()).toBe(`var foo = 42;\n\nif (foo == 42) {\n    foo++;\n}\n`);
     });
 
     it('does not fix warnings if warnings option is false', async () => {
@@ -149,7 +148,7 @@ describe('filtered-fix', () => {
       const fixOptions = { warnings: false };
       const [report] = await filteredFix.fix(filepath, fixOptions);
       expect(report.warningCount).toBe(1);
-      expect(shell.cat(filepath).toString()).toBe(`var a = (b * c);${os.EOL}`);
+      expect(shell.cat(filepath).toString()).toBe(`var a = (b * c);\n`);
     });
 
     it('performs fixes for multiple files', async () => {
@@ -160,8 +159,8 @@ describe('filtered-fix', () => {
       const [report1, report2] = await eslintCli.lintFiles([filepath1, filepath2]);
       expect(report1.errorCount).toBe(1);
       expect(report2.errorCount).toBe(0);
-      expect(shell.cat(filepath1).toString()).toBe(`var foo = 42;${os.EOL}\nif (foo == 42) {${os.EOL}    foo++;${os.EOL}}${os.EOL}`);
-      expect(shell.cat(filepath2).toString()).toBe(`var foo = 42;${os.EOL}`);
+      expect(shell.cat(filepath1).toString()).toBe(`var foo = 42;\n\nif (foo == 42) {\n    foo++;\n}\n`);
+      expect(shell.cat(filepath2).toString()).toBe(`var foo = 42;\n`);
     });
 
     it('performs fixes for directories', async () => {
@@ -172,7 +171,7 @@ describe('filtered-fix', () => {
       const [extraParens] = reports;
       expect(extraParens.filePath.endsWith('extra-parens.js')).toBe(true);
       expect(extraParens.errorCount).toBe(0);
-      expect(shell.cat(extraParens.filePath).toString()).toBe(`var a = (b * c);${os.EOL}`);
+      expect(shell.cat(extraParens.filePath).toString()).toBe(`var a = (b * c);\n`);
     });
   });
 });

--- a/src/filtered-fix.test.js
+++ b/src/filtered-fix.test.js
@@ -46,17 +46,26 @@ describe('filtered-fix', () => {
   describe('fix()', () => {
     let fixtureDir;
     const eslintCli = new ESLint();
+    const tmpDir = path.join(__dirname, '../tmp');
+
+    beforeAll(() => {
+      shell.mkdir('-p', tmpDir);
+    });
 
     beforeEach(() => {
       const prefix = crypto.randomBytes(8).toString('hex');
-      fixtureDir = path.join(__dirname, '../tmp', prefix);
-      shell.mkdir('-p', fixtureDir);
-      shell.cp('-r', path.join(__dirname, '../fixtures/*'), fixtureDir);
+      fixtureDir = path.join(tmpDir, prefix);
+      shell.cp('-r', path.join(__dirname, '../fixtures'), tmpDir);
+      shell.mv(path.join(tmpDir, 'fixtures'), fixtureDir);
       fixtureDir = fs.realpathSync(fixtureDir);
     });
 
     afterEach(() => {
       shell.rm('-r', fixtureDir);
+    });
+
+    afterAll(() => {
+      shell.rm('-r', tmpDir);
     });
 
     it('returns a report of linting errors', async () => {


### PR DESCRIPTION
# Description
This adjusts a few items to resolve some cross-OS unit test issues.

# Changelog
 - Updated how tmp fixture content was managed during unit test execution
 - Removed dependency on `os.EOL` during unit tests

# Validation
 - Validated successful unit tests on unix and Windows OS

# Reasonings

### Tmp Fixture Content
The failures seem to stem from updates from how `shell.cp` executes, likely related to the wildcard. This has been updated by the shell team in the past, breaking changes.

To resolve this, this has been updated to not be reliant on wildcard (`*`) for content, but rather directory. This will copy the contents of `./fixtures` to `./tmp/fixtures`, and then rename the directory to the "prefix" used for the next test.

### os.EOL
Tests were failing on opposing systems (unix vs windows) due to how the tests are set up. `os.EOL` will return a EOL sequence (LF vs CRLF) depending on the current OS. However, the files saved within the fixture directory already have a static EOL sequence set – in this case it's LF, or `\n`. Given this, the unit tests are using a dynamic EOL sequence based on OS but the files are static. So the unit tests would only pass on the same system as where the files were created.

I updated the unit test to remove the dynamic EOL sequence in favor of what the files are currently using, which is `\n`.

# Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bd1d744c-7507-4694-bf68-1a27e7ab4a6c" />